### PR TITLE
Remove unprotected auth token creation endpoint

### DIFF
--- a/cmd/create-auth-token/main.go
+++ b/cmd/create-auth-token/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/alces-flight/concertim-metric-reporting-daemon/config"
+	"github.com/go-chi/jwtauth/v5"
+)
+
+func main() {
+	config, err := config.FromFile(config.DefaultPaths)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %s\n", err.Error())
+		os.Exit(1)
+	}
+	tokenAuth := jwtauth.New("HS256", config.JWTSecret, nil)
+	expiresIn := time.Hour * 24
+
+	claims := map[string]interface{}{}
+	jwtauth.SetExpiryIn(claims, expiresIn)
+
+	_, tokenString, err := tokenAuth.Encode(claims)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create token: %s\n", err.Error())
+	}
+
+	fmt.Print(tokenString, "\n")
+}

--- a/docs/examples/constant-metric.sh
+++ b/docs/examples/constant-metric.sh
@@ -22,14 +22,11 @@ HOST=${1:-comp001}
 # An auth token is required for creating metrics.  One can be generated with
 # the `ct-visualisation-app/docs/api/get-auth-token.sh` script and exported as
 # the environment variable AUTH_TOKEN.
-#
-# To make testing this API easier, an unauthenticated endpoint is provided that
-# can be used to create auth tokens.  Obviously this is a security issue and
-# this end point will be removed in a future version.
-#
-# The intended mechanism is to create auth tokens either via the Concertim UI
-# or the main Concertim API and to re-use them on each request.
-AUTH_TOKEN=${AUTH_TOKEN:-$(curl -s -k -X POST "${BASE_URL}/token" -d '{}' | jq -r .token)}
+if [ -z "${AUTH_TOKEN}" ] ; then
+  echo "$(basename $0) AUTH_TOKEN not set" >&2
+  exit 1
+fi
+
 
 # Use `jq` to construct a JSON body request.
 #

--- a/docs/examples/multiple-metrics.sh
+++ b/docs/examples/multiple-metrics.sh
@@ -22,14 +22,10 @@ HOST=${1:-comp001}
 # An auth token is required for creating metrics.  One can be generated with
 # the `ct-visualisation-app/docs/api/get-auth-token.sh` script and exported as
 # the environment variable AUTH_TOKEN.
-#
-# To make testing this API easier, an unauthenticated endpoint is provided that
-# can be used to create auth tokens.  Obviously this is a security issue and
-# this end point will be removed in a future version.
-#
-# The intended mechanism is to create auth tokens either via the Concertim UI
-# or the main Concertim API and to re-use them on each request.
-AUTH_TOKEN=${AUTH_TOKEN:-$(curl -s -k -X POST "${BASE_URL}/token" -d '{}' | jq -r .token)}
+if [ -z "${AUTH_TOKEN}" ] ; then
+  echo "$(basename $0) AUTH_TOKEN not set" >&2
+  exit 1
+fi
 
 
 report_metric() {

--- a/docs/examples/variable-metric.sh
+++ b/docs/examples/variable-metric.sh
@@ -22,14 +22,11 @@ HOST=${1:-comp001}
 # An auth token is required for creating metrics.  One can be generated with
 # the `ct-visualisation-app/docs/api/get-auth-token.sh` script and exported as
 # the environment variable AUTH_TOKEN.
-#
-# To make testing this API easier, an unauthenticated endpoint is provided that
-# can be used to create auth tokens.  Obviously this is a security issue and
-# this end point will be removed in a future version.
-#
-# The intended mechanism is to create auth tokens either via the Concertim UI
-# or the main Concertim API and to re-use them on each request.
-AUTH_TOKEN=${AUTH_TOKEN:-$(curl -s -k -X POST "${BASE_URL}/token" -d '{}' | jq -r .token)}
+if [ -z "${AUTH_TOKEN}" ] ; then
+  echo "$(basename $0) AUTH_TOKEN not set" >&2
+  exit 1
+fi
+
 
 # Use `jq` to construct a JSON body request.
 #

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,9 +139,11 @@ e.g.,
 
 # Authentication
 
-Authenticed requests should set the `Authorization` header using the `Bearer` authentication strategy.  The token should be a JWT token, which can be created as described below.
+Requests requiring authentication should set the `Authorization` header using the `Bearer` authentication strategy.  The token should be a JWT token, which can be created as described below.
 
-When deployed as part of the Concertim MIA appliance, an API token can be created by visiting `System -> Appliance tools -> Access tokens`.  Entering the name of the service that the token is for and the number of days for which it should be valid.
+When deployed as part of the Concertim appliance, an API token can be created by using the ct-visualisation-app [get-auth-token.sh example script](https://github.com/alces-flight/concertim-ct-visualisation-app/blob/main/docs/api/examples/get-auth-token.sh), which will print the auth token to standard output.
+
+When running locally, an API token can be created by running, `go run cmd/create-auth-token/main.go`.  The auth token will be printed to standard output.
 
 ```
 $ curl -D - -k  -X POST http://localhost:3000/token -d '{}'


### PR DESCRIPTION
Auth tokens should now be created exclusively with ct-visualisation-app. If this makes developing this awkward, I may add a CLI tool to create an auth token for dev purposes.