### PR TITLE
Allow more configuration of various timeouts

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -42,8 +42,8 @@ func NewServer(logger zerolog.Logger, app *domain.Application, config config.API
 func (s *Server) ListenAndServe() error {
 	server := http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.config.IP, s.config.Port),
-		ReadTimeout:  time.Millisecond * 100,
-		WriteTimeout: time.Millisecond * 100,
+		ReadTimeout:  s.config.Timeout,
+		WriteTimeout: s.config.Timeout,
 		Handler:      s.addRoutes(),
 	}
 	s.httpServer = &server

--- a/config/config.dev.laptop.yml
+++ b/config/config.dev.laptop.yml
@@ -9,6 +9,13 @@ api:
   # The port to listen on.
   port: 3000
 
+  # Timeout for server to process a request.
+  #
+  # Requires a number and unit, e.g., `60s` for sixty seconds or `1h10m20s` for
+  # one hour ten minutes and twenty seconds.
+  # Valid time units are “ns”, “us” (or “µs”), “ms”, “s”, “m”, “h”.
+  timeout: 100ms
+
 # Configuration for the gangali data source server.
 gds:
   # The address of the network interface to listen on.

--- a/config/config.dev.vm.yml
+++ b/config/config.dev.vm.yml
@@ -9,6 +9,13 @@ api:
   # The port to listen on.
   port: 3000
 
+  # Timeout for server to process a request.
+  #
+  # Requires a number and unit, e.g., `60s` for sixty seconds or `1h10m20s` for
+  # one hour ten minutes and twenty seconds.
+  # Valid time units are “ns”, “us” (or “µs”), “ms”, “s”, “m”, “h”.
+  timeout: 100ms
+
 # Configuration for the gangali data source server.
 gds:
   # The address of the network interface to listen on.

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,10 @@ type Config struct {
 
 // API is the configuration for the HTTP API component.
 type API struct {
-	IP        string `yaml:"ip"`
-	Port      int    `yaml:"port"`
-	JWTSecret []byte `yaml:"-"`
+	IP        string        `yaml:"ip"`
+	JWTSecret []byte        `yaml:"-"`
+	Port      int           `yaml:"port"`
+	Timeout   time.Duration `yaml:"timeout"`
 }
 
 // GDS is the configuration for the Ganglia Data Source server component.
@@ -50,12 +51,12 @@ type DSM struct {
 
 // Retrieval is the configuration for retrieving the ganglia XML.
 type Retrieval struct {
-	PostGmetadDelay     time.Duration `yaml:"post_gmetad_delay"`
-	Frequency time.Duration `yaml:"frequency"`
-	IP        string        `yaml:"ip"`
-	Port      int           `yaml:"port"`
-	Testdata  string        `yaml:"testdata"`
-	Throttle  time.Duration `yaml:"throttle"`
+	PostGmetadDelay time.Duration `yaml:"post_gmetad_delay"`
+	Frequency       time.Duration `yaml:"frequency"`
+	IP              string        `yaml:"ip"`
+	Port            int           `yaml:"port"`
+	Testdata        string        `yaml:"testdata"`
+	Throttle        time.Duration `yaml:"throttle"`
 }
 
 // Recorder is the configuration for recording the processed results.

--- a/config/config.prod.yml
+++ b/config/config.prod.yml
@@ -6,6 +6,13 @@ api:
   # The port to listen on.
   port: 3000
 
+  # Timeout for server to process a request.
+  #
+  # Requires a number and unit, e.g., `60s` for sixty seconds or `1h10m20s` for
+  # one hour ten minutes and twenty seconds.
+  # Valid time units are “ns”, “us” (or “µs”), “ms”, “s”, “m”, “h”.
+  timeout: 100ms
+
 # Configuration for the gangali data source server.
 gds:
   # The address of the network interface to listen on.


### PR DESCRIPTION
The timeout for waiting for the DSM repo to update has been increased to 75ms.  This may or may not be fast enough to always accept the first reported metrics.  I suspect in practice it will be.  The HTTP API timeout has also been made configurable, but has not changed.