### PR TITLE
Simplify domain model

### DIFF
--- a/cmd/reporting/main.go
+++ b/cmd/reporting/main.go
@@ -163,12 +163,12 @@ func main() {
 }
 
 func runMetricProcessor(config *config.Config, dsmRepo *dsmRepository.Repo, gdsServer *gds.Server) error {
-	pollChan := make(chan []retrieval.Grid)
+	pollChan := make(chan []retrieval.Host)
 	poller, err := retrieval.New(log.Logger, config.Retrieval)
 	if err != nil {
 		return errors.Wrap(err, "creating retrieval poller")
 	}
-	processor := processing.NewProcessor(log.Logger, dsmRepo)
+	processor := processing.NewProcessor(log.Logger, dsmRepo, config.Retrieval.GridName, config.Retrieval.ClusterName)
 	recorder := processing.NewScriptRecorder(log.Logger, config.Recorder)
 
 	go func() { poller.Start(pollChan) }()
@@ -182,8 +182,8 @@ func runMetricProcessor(config *config.Config, dsmRepo *dsmRepository.Repo, gdsS
 		}
 	}()
 
-	for grids := range pollChan {
-		results, err := processor.Process(grids)
+	for hosts := range pollChan {
+		results, err := processor.Process(hosts)
 		if err != nil {
 			log.Error().Err(err).Msg("processing metrics")
 		}

--- a/config/config.dev.laptop.yml
+++ b/config/config.dev.laptop.yml
@@ -92,6 +92,14 @@ retrieval:
   # The port of the gmetad server to poll for metrics.
   port: 8651
 
+  # The ganglia grid from which to retrieve clusters.  All other grids are
+  # ignored.
+  gridName: "unspecified"
+
+  # The ganglia cluster from which to retrieve hosts.  All other clusters are
+  # ignored.
+  clusterName: "unspecified"
+
   # The metrics are periodically retrieved from the gmetad source. `frequency`
   # specifies the frequency of the periodic updating.
   #

--- a/config/config.dev.vm.yml
+++ b/config/config.dev.vm.yml
@@ -93,6 +93,14 @@ retrieval:
   # The port of the gmetad server to poll for metrics.
   port: 8651
 
+  # The ganglia grid from which to retrieve clusters.  All other grids are
+  # ignored.
+  gridName: "unspecified"
+
+  # The ganglia cluster from which to retrieve hosts.  All other clusters are
+  # ignored.
+  clusterName: "unspecified"
+
   # The metrics are periodically retrieved from the gmetad source. `frequency`
   # specifies the frequency of the periodic updating.
   #

--- a/config/config.go
+++ b/config/config.go
@@ -51,10 +51,12 @@ type DSM struct {
 
 // Retrieval is the configuration for retrieving the ganglia XML.
 type Retrieval struct {
-	PostGmetadDelay time.Duration `yaml:"post_gmetad_delay"`
+	ClusterName     string        `yaml:"clusterName"`
 	Frequency       time.Duration `yaml:"frequency"`
+	GridName        string        `yaml:"gridName"`
 	IP              string        `yaml:"ip"`
 	Port            int           `yaml:"port"`
+	PostGmetadDelay time.Duration `yaml:"post_gmetad_delay"`
 	Testdata        string        `yaml:"testdata"`
 	Throttle        time.Duration `yaml:"throttle"`
 }

--- a/config/config.prod.yml
+++ b/config/config.prod.yml
@@ -93,6 +93,14 @@ retrieval:
   # The port of the gmetad server to poll for metrics.
   port: 8651
 
+  # The ganglia grid from which to retrieve clusters.  All other grids are
+  # ignored.
+  gridName: "unspecified"
+
+  # The ganglia cluster from which to retrieve hosts.  All other clusters are
+  # ignored.
+  clusterName: "unspecified"
+
   # The metrics are periodically retrieved from the gmetad source. `frequency`
   # specifies the frequency of the periodic updating.
   #


### PR DESCRIPTION
Extract hosts prior to processing them

Move extraction of which hosts are to be processed from processing to retrieval.  This will better help with any changes that replace ganglia with some other source of metric data.