### PR TITLE
Support for adding build labels to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,15 @@ RUN go test -v -count=1 -race -shuffle=on ./api ./canned ./config ./domain ./dsm
 
 ###################
 FROM ubuntu:22.04
-LABEL com.alces-flight.concertim.role=metrics com.alces-flight.concertim.version=0.6.0-dev
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Alces Concertim Metric Reporting Daemon"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
The labels use the format specified in https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1.  The values for the labels are calculated and injected as part of https://github.com/alces-flight/concertim-ansible-playbook/pull/69.